### PR TITLE
Add draft save option and restrict sortable drop targets

### DIFF
--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -1,5 +1,6 @@
 @page "/forms/{FormId:int}/edit"
 @using System.Net.Http.Json
+@using System.Net
 @using System.Text.Json
 @using DynamicFormsApp.Client.Components
 @using DynamicFormsApp.Shared
@@ -13,6 +14,10 @@
 @implements IDisposable
 
 <h2 class="mb-2">Form Builder</h2>
+@if (!string.IsNullOrEmpty(deletedMessage))
+{
+    <div class="alert alert-warning">@deletedMessage</div>
+}
 <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 
 <div class="form-check form-switch mb-4">
@@ -129,6 +134,7 @@ else
     private bool isDraft = false;
     private UserModel? currentUser;
     private DotNetObjectReference<DynamicFormsApp.Client.Pages.DynamicForms.EditFormPage>? objRef;
+    private string? deletedMessage;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -145,7 +151,23 @@ else
             currentUser = await UserService.GetUserData(user);
             notificationEmail = currentUser?.Email ?? string.Empty;
 
-            var form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
+            var resp = await Http.GetAsync($"api/forms/{FormId}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                if (resp.StatusCode == HttpStatusCode.Gone)
+                {
+                    var info = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                }
+                else
+                {
+                    deletedMessage = "Form not found.";
+                }
+                StateHasChanged();
+                return;
+            }
+
+            var form = await resp.Content.ReadFromJsonAsync<Form>();
             formName = form.Name;
             formDescription = form.Description ?? string.Empty;
             requireLogin = form.RequireLogin;

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -91,9 +91,21 @@
                 <div class="d-grid mb-3">
                     <button class="btn btn-primary" @onclick="AddRow">+ Add Row</button>
                 </div>
-                <div class="d-grid">
-                    <button class="btn btn-primary btn-lg" @onclick="HandleSubmit">Update Form</button>
-                </div>
+                @if (isDraft)
+                {
+                    <div class="d-grid mb-2">
+                        <button class="btn btn-secondary" @onclick="SaveDraft">Save Draft</button>
+                    </div>
+                    <div class="d-grid">
+                        <button class="btn btn-primary btn-lg" @onclick="PublishForm">Publish Form</button>
+                    </div>
+                }
+                else
+                {
+                    <div class="d-grid">
+                        <button class="btn btn-primary btn-lg" @onclick="() => SubmitForm(false)">Update Form</button>
+                    </div>
+                }
             </div>
         </div>
     </div>
@@ -114,6 +126,7 @@ else
     private bool requireLogin = true;
     private bool notifyOnResponse = false;
     private string notificationEmail = string.Empty;
+    private bool isDraft = false;
     private UserModel? currentUser;
     private DotNetObjectReference<DynamicFormsApp.Client.Pages.DynamicForms.EditFormPage>? objRef;
 
@@ -138,6 +151,7 @@ else
             requireLogin = form.RequireLogin;
             notifyOnResponse = form.NotifyOnResponse;
             notificationEmail = form.NotificationEmail ?? notificationEmail;
+            isDraft = form.IsDraft;
             rows = BuildDesignerRows(form);
 
             objRef ??= DotNetObjectReference.Create(this);
@@ -213,20 +227,23 @@ else
 
     async Task RemoveField(int row, DesignerField field)
     {
-        bool? confirmed = await DialogService.Confirm(
-            "Deleting this field will create a new version of the form. Continue?",
-            "Delete Field",
-            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
-
-        if (confirmed == true)
+        if (!isDraft)
         {
-            rows[row].Fields.Remove(field);
-            if (rows[row].Fields.Count == 0 && rows.Count > 1)
-            {
-                rows.RemoveAt(row);
-            }
-            await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+            bool? confirmed = await DialogService.Confirm(
+                "Deleting this field will create a new version of the form. Continue?",
+                "Delete Field",
+                new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+
+            if (confirmed != true)
+                return;
         }
+
+        rows[row].Fields.Remove(field);
+        if (rows[row].Fields.Count == 0 && rows.Count > 1)
+        {
+            rows.RemoveAt(row);
+        }
+        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
     async Task DuplicateField(int row, DesignerField field)
@@ -342,7 +359,7 @@ else
         return result;
     }
 
-    async Task HandleSubmit()
+    async Task SubmitForm(bool draft)
     {
         if (string.IsNullOrWhiteSpace(formName))
         {
@@ -388,6 +405,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
+            IsDraft = draft,
             Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
             {
                 f.Key,
@@ -407,11 +425,23 @@ else
         var resp = await Http.PutAsJsonAsync($"api/forms/{FormId}", payload);
         if (resp.IsSuccessStatusCode)
         {
-            var wrapper = await resp.Content.ReadFromJsonAsync<JsonElement>();
-            int newId = wrapper.GetProperty("formId").GetInt32();
-            Navigation.NavigateTo($"/forms/{newId}");
+            if (draft)
+            {
+                await DialogService.Alert("Draft saved!", "Draft Saved");
+                isDraft = true;
+            }
+            else
+            {
+                var wrapper = await resp.Content.ReadFromJsonAsync<JsonElement>();
+                int newId = wrapper.GetProperty("formId").GetInt32();
+                Navigation.NavigateTo($"/forms/{newId}");
+            }
         }
     }
+
+    Task SaveDraft() => SubmitForm(true);
+
+    Task PublishForm() => SubmitForm(false);
 
     public void Dispose()
     {

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -82,7 +82,7 @@
                                              OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
                             </div>
                         }
-                        <div class="col-12">
+                        <div class="col-12 no-drop">
                             <button class="btn btn-sm btn-primary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
                         </div>
                     </div>

--- a/Client/Pages/DynamicForms/FormHistory.razor
+++ b/Client/Pages/DynamicForms/FormHistory.razor
@@ -1,11 +1,16 @@
 @page "/forms/{FormId:int}/history"
 @using System.Net.Http.Json
+@using System.Net
 @using DynamicFormsApp.Shared.Models
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 
 <h3 class="mb-3">Form Versions</h3>
+@if (!string.IsNullOrEmpty(deletedMessage))
+{
+    <div class="alert alert-warning">@deletedMessage</div>
+}
 
 @if (versions == null)
 {
@@ -30,6 +35,7 @@ else
 @code {
     [Parameter] public int FormId { get; set; }
     private List<Form>? versions;
+    private string? deletedMessage;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -43,7 +49,23 @@ else
                 return;
             }
 
-            versions = await Http.GetFromJsonAsync<List<Form>>($"api/forms/{FormId}/history");
+            var resp = await Http.GetAsync($"api/forms/{FormId}/history");
+            if (!resp.IsSuccessStatusCode)
+            {
+                if (resp.StatusCode == HttpStatusCode.Gone)
+                {
+                    var info = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                }
+                else
+                {
+                    deletedMessage = "Form not found.";
+                }
+                StateHasChanged();
+                return;
+            }
+
+            versions = await resp.Content.ReadFromJsonAsync<List<Form>>();
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -4,12 +4,17 @@
 @using System.Text.Json
 @using System.Linq
 @using DynamicFormsApp.Shared.Models
+@using System.Net
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 
 <h3>@(form?.Name ?? "Loading…")</h3>
 <p class="text-muted">@form?.Description</p>
+@if (!string.IsNullOrEmpty(deletedMessage))
+{
+    <div class="alert alert-warning">@deletedMessage</div>
+}
 
 @if (form == null)
 {
@@ -169,12 +174,29 @@ else
 
     private Form form;
     private Dictionary<string, object> responseData = new();
+    private string? deletedMessage;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
+            var resp = await Http.GetAsync($"api/forms/{FormId}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                if (resp.StatusCode == HttpStatusCode.Gone)
+                {
+                    var info = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                }
+                else
+                {
+                    deletedMessage = "Form not found.";
+                }
+                StateHasChanged();
+                return;
+            }
+
+            form = await resp.Content.ReadFromJsonAsync<Form>();
 
             var user = await CookieHelper.LoginStatus();
             if (form.RequireLogin && string.IsNullOrEmpty(user))

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -119,7 +119,7 @@
                     .ToArray();
             }
 
-            exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/exportHelper.js");
+            exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -1,5 +1,6 @@
-﻿@page "/forms/{FormId:int}/responses"
+@page "/forms/{FormId:int}/responses"
 @using System.Net.Http.Json
+@using System.Net
 @using DynamicFormsApp.Shared.Models
 @using Microsoft.AspNetCore.Components
 @inject HttpClient Http
@@ -11,6 +12,10 @@
 <div class="container mt-4">
     <h2 class="mb-4">📄 Responses: <span class="text-primary">@form?.Name</span></h2>
     <p class="text-muted">@form?.Description</p>
+    @if (!string.IsNullOrEmpty(deletedMessage))
+    {
+        <div class="alert alert-warning">@deletedMessage</div>
+    }
 
     @if (form == null || responses == null)
     {
@@ -91,6 +96,7 @@
     private List<Dictionary<string, object>> responses;
     private string[] columns = Array.Empty<string>();
     private IJSObjectReference? exportModule;
+    private string? deletedMessage;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -105,8 +111,31 @@
             }
 
 
-            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
-            responses = await Http.GetFromJsonAsync<List<Dictionary<string, object>>>($"api/forms/{FormId}/responses");
+            var respForm = await Http.GetAsync($"api/forms/{FormId}");
+            if (!respForm.IsSuccessStatusCode)
+            {
+                if (respForm.StatusCode == HttpStatusCode.Gone)
+                {
+                    var info = await respForm.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                }
+                else
+                {
+                    deletedMessage = "Form not found.";
+                }
+                StateHasChanged();
+                return;
+            }
+
+            form = await respForm.Content.ReadFromJsonAsync<Form>();
+            var respData = await Http.GetAsync($"api/forms/{FormId}/responses");
+            if (!respData.IsSuccessStatusCode)
+            {
+                deletedMessage = "Unable to load responses.";
+                StateHasChanged();
+                return;
+            }
+            responses = await respData.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
 
             var fieldKeys = form.Fields.Select(f => f.Key);
             columns = new[] { "ResponseId", "CreatedAt" }

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -1,5 +1,6 @@
-﻿@page "/forms/{FormId:int}/summary"
+@page "/forms/{FormId:int}/summary"
 @using System.Net.Http.Json
+@using System.Net
 @using System.Text.Json
 @using DynamicFormsApp.Shared.Models
 @inject HttpClient Http
@@ -8,6 +9,10 @@
 
 <h3>Summary for @form?.Name</h3>
 <p class="text-muted">@form?.Description</p>
+@if (!string.IsNullOrEmpty(deletedMessage))
+{
+    <div class="alert alert-warning">@deletedMessage</div>
+}
 
 @if (form == null || responses == null)
 {
@@ -70,6 +75,7 @@ else
 
     private Form form;
     private List<Dictionary<string, object>> responses;
+    private string? deletedMessage;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -83,8 +89,31 @@ else
                 return;
             }
 
-            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
-            responses = await Http.GetFromJsonAsync<List<Dictionary<string, object>>>($"api/forms/{FormId}/responses");
+            var respForm = await Http.GetAsync($"api/forms/{FormId}");
+            if (!respForm.IsSuccessStatusCode)
+            {
+                if (respForm.StatusCode == HttpStatusCode.Gone)
+                {
+                    var info = await respForm.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                }
+                else
+                {
+                    deletedMessage = "Form not found.";
+                }
+                StateHasChanged();
+                return;
+            }
+
+            form = await respForm.Content.ReadFromJsonAsync<Form>();
+            var resp = await Http.GetAsync($"api/forms/{FormId}/responses");
+            if (!resp.IsSuccessStatusCode)
+            {
+                deletedMessage = "Unable to load responses.";
+                StateHasChanged();
+                return;
+            }
+            responses = await resp.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
 
             StateHasChanged();
         }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -356,6 +356,7 @@ else
         {
             var wrapper = await resp.Content.ReadFromJsonAsync<JsonElement>();
             int newId = wrapper.GetProperty("formId").GetInt32();
+            ignoreNavigationPrompt = true;
             Navigation.NavigateTo($"/forms/{newId}");
         }
     }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -391,7 +391,7 @@ else
     private async Task SaveDraftAndExit()
     {
         await SaveDraftAsync();
-        await JS.InvokeVoidAsync("alert", "Draft saved! You can return later to edit or publish it.");
+        await DialogService.Alert("Draft saved! You can return later to edit or publish it.", "Draft Saved");
         ignoreNavigationPrompt = true;
         Navigation.NavigateTo("/");
     }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -93,8 +93,11 @@
                 <div class="d-grid mb-3">
                     <button class="btn btn-primary" @onclick="AddRow">+ Add Row</button>
                 </div>
-                <div class="d-grid">
+                <div class="d-grid mb-2">
                     <button class="btn btn-primary btn-lg" @onclick="HandleSubmit">Create Form</button>
+                </div>
+                <div class="d-grid">
+                    <button class="btn btn-secondary" @onclick="SaveDraftAndExit">Save as Draft</button>
                 </div>
             </div>
         </div>
@@ -383,6 +386,13 @@ else
         };
 
         await Http.PostAsJsonAsync("api/forms", payload);
+    }
+
+    private async Task SaveDraftAndExit()
+    {
+        await SaveDraftAsync();
+        ignoreNavigationPrompt = true;
+        Navigation.NavigateTo("/");
     }
 
     private async Task PromptDraft(LocationChangingContext context)

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -84,7 +84,7 @@
                                              OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
                             </div>
                         }
-                        <div class="col-12">
+                        <div class="col-12 no-drop">
                             <button class="btn btn-sm btn-primary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
                         </div>
                     </div>
@@ -391,6 +391,7 @@ else
     private async Task SaveDraftAndExit()
     {
         await SaveDraftAsync();
+        await JS.InvokeVoidAsync("alert", "Draft saved! You can return later to edit or publish it.");
         ignoreNavigationPrompt = true;
         Navigation.NavigateTo("/");
     }

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -1,5 +1,6 @@
 @page "/forms/{FormId:int}/responses/{ResponseId:int}"
 @using System.Net.Http.Json
+@using System.Net
 @using System.Text.Json
 @using DynamicFormsApp.Shared.Models
 @inject HttpClient Http
@@ -16,8 +17,12 @@
             <span class="text-muted">Submitted by @responderName</span>
         }
     </div>
-   
+
 </div>
+@if (!string.IsNullOrEmpty(deletedMessage))
+{
+    <div class="alert alert-warning">@deletedMessage</div>
+}
 <p class="text-muted">@form?.Description</p>
 <div class="mb-3" role="group">
     <button class="btn btn-outline-info me-2" @onclick="PrintResponse">Print</button>
@@ -74,6 +79,7 @@ else
     private Dictionary<string, object>? response;
     private string? responderName;
     private IJSObjectReference? exportModule;
+    private string? deletedMessage;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -88,8 +94,32 @@ else
             }
 
 
-            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
-            response = await Http.GetFromJsonAsync<Dictionary<string, object>>($"api/forms/{FormId}/responses/{ResponseId}");
+            var respForm = await Http.GetAsync($"api/forms/{FormId}");
+            if (!respForm.IsSuccessStatusCode)
+            {
+                if (respForm.StatusCode == HttpStatusCode.Gone)
+                {
+                    var info = await respForm.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                }
+                else
+                {
+                    deletedMessage = "Form not found.";
+                }
+                StateHasChanged();
+                return;
+            }
+
+            form = await respForm.Content.ReadFromJsonAsync<Form>();
+
+            var resp = await Http.GetAsync($"api/forms/{FormId}/responses/{ResponseId}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                deletedMessage = "Response not found.";
+                StateHasChanged();
+                return;
+            }
+            response = await resp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
             if (response.TryGetValue("ResponderName", out var respName))
             {
                 responderName = respName?.ToString();

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -94,7 +94,7 @@ else
             {
                 responderName = respName?.ToString();
             }
-            exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/exportHelper.js");
+            exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -19,6 +19,12 @@
    
 </div>
 <p class="text-muted">@form?.Description</p>
+<div class="mb-3" role="group">
+    <button class="btn btn-outline-info me-2" @onclick="PrintResponse">Print</button>
+    <button class="btn btn-outline-info me-2" @onclick="DownloadPdf">Download PDF</button>
+    <button class="btn btn-outline-info me-2" @onclick="DownloadCsv">Download CSV</button>
+    <button class="btn btn-outline-info" @onclick="DownloadExcel">Download Excel</button>
+</div>
 
 @if (form == null || response == null)
 {
@@ -172,6 +178,54 @@ else
             return val;
         }
         return val;
+    }
+
+    private async Task DownloadCsv()
+    {
+        if (exportModule is not null)
+        {
+            await exportModule.InvokeVoidAsync("downloadTableCsv", "exportTable", $"{form?.Name ?? "response"}.csv");
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("downloadTableCsv", "exportTable", $"{form?.Name ?? "response"}.csv");
+        }
+    }
+
+    private async Task DownloadPdf()
+    {
+        if (exportModule is not null)
+        {
+            await exportModule.InvokeVoidAsync("exportTableToPdf", "printArea", $"{form?.Name ?? "response"}.pdf");
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("exportTableToPdf", "printArea", $"{form?.Name ?? "response"}.pdf");
+        }
+    }
+
+    private async Task DownloadExcel()
+    {
+        if (exportModule is not null)
+        {
+            await exportModule.InvokeVoidAsync("exportTableToExcel", "exportTable", $"{form?.Name ?? "response"}.xlsx");
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("exportTableToExcel", "exportTable", $"{form?.Name ?? "response"}.xlsx");
+        }
+    }
+
+    private async Task PrintResponse()
+    {
+        if (exportModule is not null)
+        {
+            await exportModule.InvokeVoidAsync("printElement", "printArea");
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("printElement", "printArea");
+        }
     }
 
 

--- a/NdaProcesses.Shared/Models/DeletedFormInfo.cs
+++ b/NdaProcesses.Shared/Models/DeletedFormInfo.cs
@@ -1,0 +1,9 @@
+namespace DynamicFormsApp.Shared.Models
+{
+    public class DeletedFormInfo
+    {
+        public string Message { get; set; } = string.Empty;
+        public string Owner { get; set; } = string.Empty;
+        public string? Email { get; set; }
+    }
+}

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -34,6 +34,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/docx/8.0.0/docx.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.19.3/xlsx.full.min.js"></script>
     <script>
         // Exposes window.captureScreenshot() ? Promise<string dataUrl>
         window.captureScreenshot = async () => {

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -28,7 +28,7 @@
     <script src="js/sortable-wrapper.js"></script>
     <script src="js/dragdrop-wrapper.js"></script>
     <script src="js/chartInterop.js"></script>
-    <script src="js/exportHelper.js"></script>
+    <script type="module" src="js/exportHelper.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -57,6 +57,17 @@ namespace DynamicFormsApp.Server.Controllers
             {
                 return Unauthorized();
             }
+            var form = await _svc.GetFormAsync(id);
+            if (!form.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
 
             var rows = await _svc.GetResponsesAsync(id, user);
             return Ok(rows);
@@ -70,6 +81,18 @@ namespace DynamicFormsApp.Server.Controllers
                 return Unauthorized();
             }
 
+            var form = await _svc.GetFormAsync(id);
+            if (!form.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
+
             var row = await _svc.GetResponseAsync(id, responseId, user);
             return Ok(row);
         }
@@ -80,12 +103,33 @@ namespace DynamicFormsApp.Server.Controllers
         public async Task<ActionResult<Form>> Get(int id)
         {
             var form = await _svc.GetFormAsync(id);
+            if (!form.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
             return Ok(form);
         }
 
         [HttpGet("{id}/history")]
         public async Task<ActionResult<IEnumerable<Form>>> History(int id)
         {
+            var current = await _svc.GetFormAsync(id);
+            if (!current.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(current.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? current.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
             var history = await _svc.GetFormHistoryAsync(id);
             return Ok(history);
         }
@@ -206,6 +250,16 @@ namespace DynamicFormsApp.Server.Controllers
             {
                 string? responder = null;
                 var form = await _svc.GetFormAsync(id);
+                if (!form.IsActive)
+                {
+                    var owner = await _userSvc.GetUserData(form.CreatedBy);
+                    return StatusCode(410, new
+                    {
+                        Message = "This form has been deleted. Please contact the owner.",
+                        Owner = owner?.DisplayName ?? form.CreatedBy,
+                        Email = owner?.Email
+                    });
+                }
                 if (form.RequireLogin && Request.Cookies.TryGetValue("userName", out var userId) && !string.IsNullOrEmpty(userId))
                 {
                     var userData = await _userSvc.GetUserData(userId);

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -193,16 +193,21 @@ namespace DynamicFormsApp.Server.Services
 
         public async Task<Form> GetFormAsync(int formId)
         {
-            return await _db.Forms
+            var form = await _db.Forms
                 .Include(f => f.Fields)
                 .FirstOrDefaultAsync(f => f.Id == formId)
                 ?? throw new InvalidOperationException("Form not found");
+            return form;
         }
 
         public async Task<Form> StoreResponseAsync(int formId, Dictionary<string, object> values, string? responderName = null)
         {
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
+            if (!form.IsActive)
+            {
+                throw new InvalidOperationException("Form inactive");
+            }
             var rawName = SanitizeKey(form.Name);
             var tableName = $"Form_{formId}_{rawName}";
 
@@ -374,7 +379,7 @@ namespace DynamicFormsApp.Server.Services
             var formIds = await _db.FormShares.Where(s => s.UserName == user).Select(s => s.FormId).ToListAsync();
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => formIds.Contains(f.Id))
+                .Where(f => formIds.Contains(f.Id) && f.IsActive)
                 .ToListAsync();
         }
 
@@ -422,6 +427,10 @@ namespace DynamicFormsApp.Server.Services
 
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
+            if (!form.IsActive)
+            {
+                throw new InvalidOperationException("Form inactive");
+            }
             var rawName = SanitizeKey(form.Name);
             var tableName = $"Form_{formId}_{rawName}";
 
@@ -459,6 +468,10 @@ namespace DynamicFormsApp.Server.Services
 
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
+            if (!form.IsActive)
+            {
+                throw new InvalidOperationException("Form inactive");
+            }
             var rawName = SanitizeKey(form.Name);
             var tableName = $"Form_{formId}_{rawName}";
 

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -57,15 +57,29 @@ namespace DynamicFormsApp.Server.Services
 
             if (deletions.Count > 0)
             {
-                // Deleting fields requires a new version with a fresh table
-                existing.IsActive = false;
-                await _db.SaveChangesAsync();
+                if (!existing.IsDraft)
+                {
+                    // Deleting fields requires a new version with a fresh table
+                    existing.IsActive = false;
+                    await _db.SaveChangesAsync();
 
-                var newId = await CreateFormAsync(dto.Name, dto.Description, dto.Fields, user,
-                    dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive,
-                    dto.IsDraft, existing.Version + 1, existing.Id);
+                    var newId = await CreateFormAsync(dto.Name, dto.Description, dto.Fields, user,
+                        dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive,
+                        dto.IsDraft, existing.Version + 1, existing.Id);
 
-                return newId;
+                    return newId;
+                }
+                else
+                {
+                    var rawName = SanitizeKey(existing.Name);
+                    var tableName = $"Form_{existing.Id}_{rawName}";
+                    foreach (var del in deletions)
+                    {
+                        var sql = $"ALTER TABLE [{tableName}] DROP COLUMN [{del.Key}];";
+                        await _db.Database.ExecuteSqlRawAsync(sql);
+                        _db.FormFields.Remove(del);
+                    }
+                }
             }
 
             // Update in place when no fields are removed

--- a/Server/wwwroot/js/exportHelper.js
+++ b/Server/wwwroot/js/exportHelper.js
@@ -72,6 +72,26 @@ export async function exportTableToDocx(elementId, filename) {
 };
 window.exportTableToDocx = exportTableToDocx;
 
+export function exportTableToExcel(tableId, filename) {
+    const table = document.getElementById(tableId);
+    if (!table) return;
+    if (!window.XLSX) {
+        alert('Excel export is unavailable.');
+        return;
+    }
+    const wb = XLSX.utils.table_to_book(table, { sheet: 'Sheet1' });
+    const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+};
+window.exportTableToExcel = exportTableToExcel;
+
 export function printElement(elementId) {
     const el = document.getElementById(elementId);
     if (!el) return;

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -10,9 +10,9 @@ window.initSortable = (selector, dotnetHelper) => {
             animation: 150,
             handle: '.drag-handle',
             draggable: '[data-id]',
-            filter: '.no-drop',
+            filter: '.no-drop, .no-drop *',
             onMove: function (evt) {
-                if (evt.related && evt.related.classList.contains('no-drop')) {
+                if (evt.related && (evt.related.classList.contains('no-drop') || evt.related.closest('.no-drop'))) {
                     return false;
                 }
             },

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -10,6 +10,12 @@ window.initSortable = (selector, dotnetHelper) => {
             animation: 150,
             handle: '.drag-handle',
             draggable: '[data-id]',
+            filter: '.no-drop',
+            onMove: function (evt) {
+                if (evt.related && evt.related.classList.contains('no-drop')) {
+                    return false;
+                }
+            },
             onEnd: function (evt) {
                 const fromRow = evt.from.getAttribute('data-row');
                 const toRow = evt.to.getAttribute('data-row');

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -9,6 +9,7 @@ window.initSortable = (selector, dotnetHelper) => {
             group: 'rows',
             animation: 150,
             handle: '.drag-handle',
+            draggable: '[data-id]',
             onEnd: function (evt) {
                 const fromRow = evt.from.getAttribute('data-row');
                 const toRow = evt.to.getAttribute('data-row');


### PR DESCRIPTION
## Summary
- keep `+ Add Column` from being a drop target by configuring Sortable
- allow saving a new form as a draft with a dedicated button

## Testing
- `dotnet build DynamicFormsApp.sln --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6f66a8a083299c88e84f856b6e5b