### PR TITLE
Add form activation toggle

### DIFF
--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -12,6 +12,15 @@
 
 @implements IDisposable
 
+@if (deletedInfo != null)
+{
+    <div class="alert alert-danger">
+        @deletedInfo.Message<br />
+        Owner: @deletedInfo.OwnerName (@deletedInfo.OwnerEmail)
+    </div>
+}
+else
+{
 <h2 class="mb-2">Form Builder</h2>
 <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 
@@ -82,7 +91,7 @@
                                              OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
                             </div>
                         }
-                        <div class="col-12">
+                        <div class="col-12 no-drop">
                             <button class="btn btn-sm btn-primary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
                         </div>
                     </div>
@@ -91,9 +100,21 @@
                 <div class="d-grid mb-3">
                     <button class="btn btn-primary" @onclick="AddRow">+ Add Row</button>
                 </div>
-                <div class="d-grid">
-                    <button class="btn btn-primary btn-lg" @onclick="HandleSubmit">Update Form</button>
-                </div>
+                @if (isDraft)
+                {
+                    <div class="d-grid mb-2">
+                        <button class="btn btn-secondary" @onclick="SaveDraft">Save Draft</button>
+                    </div>
+                    <div class="d-grid">
+                        <button class="btn btn-primary btn-lg" @onclick="PublishForm">Publish Form</button>
+                    </div>
+                }
+                else
+                {
+                    <div class="d-grid">
+                        <button class="btn btn-primary btn-lg" @onclick="() => SubmitForm(false)">Update Form</button>
+                    </div>
+                }
             </div>
         </div>
     </div>
@@ -103,6 +124,7 @@ else
     <div class="card p-3 shadow-sm">
         <LivePreview Rows="rows" FormName="@formName" />
     </div>
+}
 }
 
 @code {
@@ -114,6 +136,8 @@ else
     private bool requireLogin = true;
     private bool notifyOnResponse = false;
     private string notificationEmail = string.Empty;
+    private bool isDraft = false;
+    private DeletedFormInfo? deletedInfo;
     private UserModel? currentUser;
     private DotNetObjectReference<DynamicFormsApp.Client.Pages.DynamicForms.EditFormPage>? objRef;
 
@@ -132,12 +156,21 @@ else
             currentUser = await UserService.GetUserData(user);
             notificationEmail = currentUser?.Email ?? string.Empty;
 
-            var form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
+            var resp = await Http.GetAsync($"api/forms/{FormId}");
+            if (resp.StatusCode == System.Net.HttpStatusCode.Gone)
+            {
+                deletedInfo = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                StateHasChanged();
+                return;
+            }
+            resp.EnsureSuccessStatusCode();
+            var form = await resp.Content.ReadFromJsonAsync<Form>();
             formName = form.Name;
             formDescription = form.Description ?? string.Empty;
             requireLogin = form.RequireLogin;
             notifyOnResponse = form.NotifyOnResponse;
             notificationEmail = form.NotificationEmail ?? notificationEmail;
+            isDraft = form.IsDraft;
             rows = BuildDesignerRows(form);
 
             objRef ??= DotNetObjectReference.Create(this);
@@ -213,20 +246,23 @@ else
 
     async Task RemoveField(int row, DesignerField field)
     {
-        bool? confirmed = await DialogService.Confirm(
-            "Deleting this field will create a new version of the form. Continue?",
-            "Delete Field",
-            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
-
-        if (confirmed == true)
+        if (!isDraft)
         {
-            rows[row].Fields.Remove(field);
-            if (rows[row].Fields.Count == 0 && rows.Count > 1)
-            {
-                rows.RemoveAt(row);
-            }
-            await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+            bool? confirmed = await DialogService.Confirm(
+                "Deleting this field will create a new version of the form. Continue?",
+                "Delete Field",
+                new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+
+            if (confirmed != true)
+                return;
         }
+
+        rows[row].Fields.Remove(field);
+        if (rows[row].Fields.Count == 0 && rows.Count > 1)
+        {
+            rows.RemoveAt(row);
+        }
+        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
     async Task DuplicateField(int row, DesignerField field)
@@ -342,7 +378,7 @@ else
         return result;
     }
 
-    async Task HandleSubmit()
+    async Task SubmitForm(bool draft)
     {
         if (string.IsNullOrWhiteSpace(formName))
         {
@@ -388,6 +424,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
+            IsDraft = draft,
             Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
             {
                 f.Key,
@@ -407,11 +444,23 @@ else
         var resp = await Http.PutAsJsonAsync($"api/forms/{FormId}", payload);
         if (resp.IsSuccessStatusCode)
         {
-            var wrapper = await resp.Content.ReadFromJsonAsync<JsonElement>();
-            int newId = wrapper.GetProperty("formId").GetInt32();
-            Navigation.NavigateTo($"/forms/{newId}");
+            if (draft)
+            {
+                await DialogService.Alert("Draft saved!", "Draft Saved");
+                isDraft = true;
+            }
+            else
+            {
+                var wrapper = await resp.Content.ReadFromJsonAsync<JsonElement>();
+                int newId = wrapper.GetProperty("formId").GetInt32();
+                Navigation.NavigateTo($"/forms/{newId}");
+            }
         }
     }
+
+    Task SaveDraft() => SubmitForm(true);
+
+    Task PublishForm() => SubmitForm(false);
 
     public void Dispose()
     {

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -1,4 +1,4 @@
-﻿@page "/razer"
+@page "/razer"
 @using System.Net.Http.Json
 @using System.Text.Json
 @using DynamicFormsApp.Shared.Models

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -8,6 +8,15 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 
+@if (deletedInfo != null)
+{
+    <div class="alert alert-danger">
+        @deletedInfo.Message<br />
+        Owner: @deletedInfo.OwnerName (@deletedInfo.OwnerEmail)
+    </div>
+}
+else
+{
 <h3>@(form?.Name ?? "Loading…")</h3>
 <p class="text-muted">@form?.Description</p>
 
@@ -169,12 +178,21 @@ else
 
     private Form form;
     private Dictionary<string, object> responseData = new();
+    private DeletedFormInfo? deletedInfo;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
+            var resp = await Http.GetAsync($"api/forms/{FormId}");
+            if (resp.StatusCode == System.Net.HttpStatusCode.Gone)
+            {
+                deletedInfo = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                StateHasChanged();
+                return;
+            }
+            resp.EnsureSuccessStatusCode();
+            form = await resp.Content.ReadFromJsonAsync<Form>();
 
             var user = await CookieHelper.LoginStatus();
             if (form.RequireLogin && string.IsNullOrEmpty(user))

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -1,4 +1,4 @@
-﻿@page "/forms/{FormId:int}"
+@page "/forms/{FormId:int}"
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using System.Text.Json

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -1,4 +1,4 @@
-﻿@page "/forms/{FormId:int}/responses"
+@page "/forms/{FormId:int}/responses"
 @using System.Net.Http.Json
 @using DynamicFormsApp.Shared.Models
 @using Microsoft.AspNetCore.Components

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -9,6 +9,15 @@
 @implements IAsyncDisposable
 
 <div class="container mt-4">
+    @if (deletedInfo != null)
+    {
+        <div class="alert alert-danger">
+            @deletedInfo.Message<br />
+            Owner: @deletedInfo.OwnerName (@deletedInfo.OwnerEmail)
+        </div>
+    }
+    else
+    {
     <h2 class="mb-4">📄 Responses: <span class="text-primary">@form?.Name</span></h2>
     <p class="text-muted">@form?.Description</p>
 
@@ -89,6 +98,7 @@
 
     private Form form;
     private List<Dictionary<string, object>> responses;
+    private DeletedFormInfo? deletedInfo;
     private string[] columns = Array.Empty<string>();
     private IJSObjectReference? exportModule;
 
@@ -105,7 +115,16 @@
             }
 
 
-            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
+            var resp = await Http.GetAsync($"api/forms/{FormId}");
+            if (resp.StatusCode == System.Net.HttpStatusCode.Gone)
+            {
+                deletedInfo = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                StateHasChanged();
+                return;
+            }
+            resp.EnsureSuccessStatusCode();
+            form = await resp.Content.ReadFromJsonAsync<Form>();
+
             responses = await Http.GetFromJsonAsync<List<Dictionary<string, object>>>($"api/forms/{FormId}/responses");
 
             var fieldKeys = form.Fields.Select(f => f.Key);
@@ -119,7 +138,7 @@
                     .ToArray();
             }
 
-            exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/exportHelper.js");
+            exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -6,6 +6,15 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 
+@if (deletedInfo != null)
+{
+    <div class="alert alert-danger">
+        @deletedInfo.Message<br />
+        Owner: @deletedInfo.OwnerName (@deletedInfo.OwnerEmail)
+    </div>
+}
+else
+{
 <h3>Summary for @form?.Name</h3>
 <p class="text-muted">@form?.Description</p>
 
@@ -70,6 +79,7 @@ else
 
     private Form form;
     private List<Dictionary<string, object>> responses;
+    private DeletedFormInfo? deletedInfo;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -83,7 +93,15 @@ else
                 return;
             }
 
-            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
+            var resp = await Http.GetAsync($"api/forms/{FormId}");
+            if (resp.StatusCode == System.Net.HttpStatusCode.Gone)
+            {
+                deletedInfo = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                StateHasChanged();
+                return;
+            }
+            resp.EnsureSuccessStatusCode();
+            form = await resp.Content.ReadFromJsonAsync<Form>();
             responses = await Http.GetFromJsonAsync<List<Dictionary<string, object>>>($"api/forms/{FormId}/responses");
 
             StateHasChanged();

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -1,4 +1,4 @@
-﻿@page "/forms/{FormId:int}/summary"
+@page "/forms/{FormId:int}/summary"
 @using System.Net.Http.Json
 @using System.Text.Json
 @using DynamicFormsApp.Shared.Models

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -84,7 +84,7 @@
                                              OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
                             </div>
                         }
-                        <div class="col-12">
+                        <div class="col-12 no-drop">
                             <button class="btn btn-sm btn-primary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
                         </div>
                     </div>
@@ -93,8 +93,11 @@
                 <div class="d-grid mb-3">
                     <button class="btn btn-primary" @onclick="AddRow">+ Add Row</button>
                 </div>
-                <div class="d-grid">
+                <div class="d-grid mb-2">
                     <button class="btn btn-primary btn-lg" @onclick="HandleSubmit">Create Form</button>
+                </div>
+                <div class="d-grid">
+                    <button class="btn btn-secondary" @onclick="SaveDraftAndExit">Save as Draft</button>
                 </div>
             </div>
         </div>
@@ -353,6 +356,7 @@ else
         {
             var wrapper = await resp.Content.ReadFromJsonAsync<JsonElement>();
             int newId = wrapper.GetProperty("formId").GetInt32();
+            ignoreNavigationPrompt = true;
             Navigation.NavigateTo($"/forms/{newId}");
         }
     }
@@ -383,6 +387,14 @@ else
         };
 
         await Http.PostAsJsonAsync("api/forms", payload);
+    }
+
+    private async Task SaveDraftAndExit()
+    {
+        await SaveDraftAsync();
+        await DialogService.Alert("Draft saved! You can return later to edit or publish it.", "Draft Saved");
+        ignoreNavigationPrompt = true;
+        Navigation.NavigateTo("/");
     }
 
     private async Task PromptDraft(LocationChangingContext context)

--- a/Client/Pages/DynamicForms/MyForms.razor
+++ b/Client/Pages/DynamicForms/MyForms.razor
@@ -25,6 +25,7 @@ else
                 <tr>
                     <th>Name</th>
                     <th>Description</th>
+                    <th>Active</th>
                     <th></th>
                 </tr>
             </thead>
@@ -34,6 +35,9 @@ else
                     <tr>
                         <td>@f.Name</td>
                         <td>@f.Description</td>
+                        <td>
+                            <input type="checkbox" class="form-check-input" checked="@f.IsActive" @onchange="e => ToggleActive(f, e)" />
+                        </td>
                         <td>
                             <a class="btn btn-sm btn-primary me-2" href="@($"/forms/{f.Id}")">Open</a>
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/edit")">Edit</a>
@@ -101,6 +105,13 @@ else
                 Detail = item.Name
             });
         StateHasChanged();
+    }
+
+    private async Task ToggleActive(Form f, ChangeEventArgs e)
+    {
+        bool active = (bool)e.Value;
+        await Http.PutAsJsonAsync($"api/forms/{f.Id}/active", active);
+        f.IsActive = active;
     }
 
     private async Task ShareForm(int id)

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -8,6 +8,15 @@
 @inject IJSRuntime JS
 @implements IAsyncDisposable
 
+@if (deletedInfo != null)
+{
+    <div class="alert alert-danger">
+        @deletedInfo.Message<br />
+        Owner: @deletedInfo.OwnerName (@deletedInfo.OwnerEmail)
+    </div>
+}
+else
+{
 <div class="d-flex justify-content-between align-items-center mb-2">
     <div>
         <h3 class="mb-0">Response for @form?.Name</h3>
@@ -16,9 +25,15 @@
             <span class="text-muted">Submitted by @responderName</span>
         }
     </div>
-   
+
 </div>
 <p class="text-muted">@form?.Description</p>
+<div class="mb-3" role="group">
+    <button class="btn btn-outline-info me-2" @onclick="PrintResponse">Print</button>
+    <button class="btn btn-outline-info me-2" @onclick="DownloadPdf">Download PDF</button>
+    <button class="btn btn-outline-info me-2" @onclick="DownloadCsv">Download CSV</button>
+    <button class="btn btn-outline-info" @onclick="DownloadExcel">Download Excel</button>
+</div>
 
 @if (form == null || response == null)
 {
@@ -68,6 +83,7 @@ else
     private Dictionary<string, object>? response;
     private string? responderName;
     private IJSObjectReference? exportModule;
+    private DeletedFormInfo? deletedInfo;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -82,13 +98,21 @@ else
             }
 
 
-            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
+            var resp = await Http.GetAsync($"api/forms/{FormId}");
+            if (resp.StatusCode == System.Net.HttpStatusCode.Gone)
+            {
+                deletedInfo = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
+                StateHasChanged();
+                return;
+            }
+            resp.EnsureSuccessStatusCode();
+            form = await resp.Content.ReadFromJsonAsync<Form>();
             response = await Http.GetFromJsonAsync<Dictionary<string, object>>($"api/forms/{FormId}/responses/{ResponseId}");
             if (response.TryGetValue("ResponderName", out var respName))
             {
                 responderName = respName?.ToString();
             }
-            exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/exportHelper.js");
+            exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
             StateHasChanged();
         }
     }
@@ -172,6 +196,54 @@ else
             return val;
         }
         return val;
+    }
+
+    private async Task DownloadCsv()
+    {
+        if (exportModule is not null)
+        {
+            await exportModule.InvokeVoidAsync("downloadTableCsv", "exportTable", $"{form?.Name ?? "response"}.csv");
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("downloadTableCsv", "exportTable", $"{form?.Name ?? "response"}.csv");
+        }
+    }
+
+    private async Task DownloadPdf()
+    {
+        if (exportModule is not null)
+        {
+            await exportModule.InvokeVoidAsync("exportTableToPdf", "printArea", $"{form?.Name ?? "response"}.pdf");
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("exportTableToPdf", "printArea", $"{form?.Name ?? "response"}.pdf");
+        }
+    }
+
+    private async Task DownloadExcel()
+    {
+        if (exportModule is not null)
+        {
+            await exportModule.InvokeVoidAsync("exportTableToExcel", "exportTable", $"{form?.Name ?? "response"}.xlsx");
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("exportTableToExcel", "exportTable", $"{form?.Name ?? "response"}.xlsx");
+        }
+    }
+
+    private async Task PrintResponse()
+    {
+        if (exportModule is not null)
+        {
+            await exportModule.InvokeVoidAsync("printElement", "printArea");
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("printElement", "printArea");
+        }
     }
 
 

--- a/NdaProcesses.Shared/Models/DeletedFormInfo.cs
+++ b/NdaProcesses.Shared/Models/DeletedFormInfo.cs
@@ -1,0 +1,10 @@
+namespace DynamicFormsApp.Shared.Models
+{
+    public class DeletedFormInfo
+    {
+        public string Message { get; set; } = "This form is no longer available. Please contact the owner.";
+        public string? CreatedBy { get; set; }
+        public string? OwnerEmail { get; set; }
+        public string? OwnerName { get; set; }
+    }
+}

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -28,12 +28,13 @@
     <script src="js/sortable-wrapper.js"></script>
     <script src="js/dragdrop-wrapper.js"></script>
     <script src="js/chartInterop.js"></script>
-    <script src="js/exportHelper.js"></script>
+    <script type="module" src="js/exportHelper.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/docx/8.0.0/docx.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.19.3/xlsx.full.min.js"></script>
     <script>
         // Exposes window.captureScreenshot() ? Promise<string dataUrl>
         window.captureScreenshot = async () => {

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -58,6 +58,17 @@ namespace DynamicFormsApp.Server.Controllers
                 return Unauthorized();
             }
 
+            var form = await _svc.GetFormAsync(id);
+            if (!form.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new DeletedFormInfo
+                {
+                    CreatedBy = form.CreatedBy,
+                    OwnerEmail = owner?.Email,
+                    OwnerName = owner?.DisplayName
+                });
+            }
             var rows = await _svc.GetResponsesAsync(id, user);
             return Ok(rows);
         }
@@ -70,6 +81,17 @@ namespace DynamicFormsApp.Server.Controllers
                 return Unauthorized();
             }
 
+            var form = await _svc.GetFormAsync(id);
+            if (!form.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new DeletedFormInfo
+                {
+                    CreatedBy = form.CreatedBy,
+                    OwnerEmail = owner?.Email,
+                    OwnerName = owner?.DisplayName
+                });
+            }
             var row = await _svc.GetResponseAsync(id, responseId, user);
             return Ok(row);
         }
@@ -80,6 +102,16 @@ namespace DynamicFormsApp.Server.Controllers
         public async Task<ActionResult<Form>> Get(int id)
         {
             var form = await _svc.GetFormAsync(id);
+            if (!form.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new DeletedFormInfo
+                {
+                    CreatedBy = form.CreatedBy,
+                    OwnerEmail = owner?.Email,
+                    OwnerName = owner?.DisplayName
+                });
+            }
             return Ok(form);
         }
 
@@ -161,6 +193,18 @@ namespace DynamicFormsApp.Server.Controllers
             return NoContent();
         }
 
+        [HttpPut("{id}/active")]
+        public async Task<IActionResult> SetActive(int id, [FromBody] bool active)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            await _svc.SetFormActiveAsync(id, user, active);
+            return NoContent();
+        }
+
         [HttpPost("{id}/share")]
         public async Task<IActionResult> Share(int id, [FromBody] ShareFormDto dto)
         {
@@ -206,6 +250,16 @@ namespace DynamicFormsApp.Server.Controllers
             {
                 string? responder = null;
                 var form = await _svc.GetFormAsync(id);
+                if (!form.IsActive)
+                {
+                    var owner = await _userSvc.GetUserData(form.CreatedBy);
+                    return StatusCode(410, new DeletedFormInfo
+                    {
+                        CreatedBy = form.CreatedBy,
+                        OwnerEmail = owner?.Email,
+                        OwnerName = owner?.DisplayName
+                    });
+                }
                 if (form.RequireLogin && Request.Cookies.TryGetValue("userName", out var userId) && !string.IsNullOrEmpty(userId))
                 {
                     var userData = await _userSvc.GetUserData(userId);

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -57,15 +57,29 @@ namespace DynamicFormsApp.Server.Services
 
             if (deletions.Count > 0)
             {
-                // Deleting fields requires a new version with a fresh table
-                existing.IsActive = false;
-                await _db.SaveChangesAsync();
+                if (!existing.IsDraft)
+                {
+                    // Deleting fields requires a new version with a fresh table
+                    existing.IsActive = false;
+                    await _db.SaveChangesAsync();
 
-                var newId = await CreateFormAsync(dto.Name, dto.Description, dto.Fields, user,
-                    dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive,
-                    dto.IsDraft, existing.Version + 1, existing.Id);
+                    var newId = await CreateFormAsync(dto.Name, dto.Description, dto.Fields, user,
+                        dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive,
+                        dto.IsDraft, existing.Version + 1, existing.Id);
 
-                return newId;
+                    return newId;
+                }
+                else
+                {
+                    var rawName = SanitizeKey(existing.Name);
+                    var tableName = $"Form_{existing.Id}_{rawName}";
+                    foreach (var del in deletions)
+                    {
+                        var sql = $"ALTER TABLE [{tableName}] DROP COLUMN [{del.Key}];";
+                        await _db.Database.ExecuteSqlRawAsync(sql);
+                        _db.FormFields.Remove(del);
+                    }
+                }
             }
 
             // Update in place when no fields are removed
@@ -189,6 +203,10 @@ namespace DynamicFormsApp.Server.Services
         {
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
+            if (!form.IsActive)
+            {
+                throw new InvalidOperationException("Form inactive");
+            }
             var rawName = SanitizeKey(form.Name);
             var tableName = $"Form_{formId}_{rawName}";
 
@@ -256,6 +274,18 @@ namespace DynamicFormsApp.Server.Services
             await _db.SaveChangesAsync();
         }
 
+        public async Task SetFormActiveAsync(int formId, string user, bool active)
+        {
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.CreatedBy == user);
+            if (form == null)
+            {
+                throw new InvalidOperationException("Form not found");
+            }
+
+            form.IsActive = active;
+            await _db.SaveChangesAsync();
+        }
+
         public async Task<List<Form>> GetAllFormsAsync()
         {
             return await _db.Forms
@@ -287,7 +317,7 @@ namespace DynamicFormsApp.Server.Services
         {
             var query = _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.CreatedBy == user && f.IsActive);
+                .Where(f => f.CreatedBy == user && f.PreviousVersionId == null);
 
             if (!includeDrafts)
             {
@@ -360,13 +390,13 @@ namespace DynamicFormsApp.Server.Services
             var formIds = await _db.FormShares.Where(s => s.UserName == user).Select(s => s.FormId).ToListAsync();
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => formIds.Contains(f.Id))
+                .Where(f => formIds.Contains(f.Id) && f.IsActive)
                 .ToListAsync();
         }
 
         private async Task<bool> HasResponseAccessAsync(int formId, string user)
         {
-            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId);
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.IsActive);
             if (form == null) return false;
             if (form.CreatedBy == user) return true;
             return await _db.FormShares.AnyAsync(s => s.FormId == formId && s.UserName == user);
@@ -408,6 +438,10 @@ namespace DynamicFormsApp.Server.Services
 
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
+            if (!form.IsActive)
+            {
+                throw new InvalidOperationException("Form inactive");
+            }
             var rawName = SanitizeKey(form.Name);
             var tableName = $"Form_{formId}_{rawName}";
 

--- a/Server/wwwroot/js/exportHelper.js
+++ b/Server/wwwroot/js/exportHelper.js
@@ -72,6 +72,26 @@ export async function exportTableToDocx(elementId, filename) {
 };
 window.exportTableToDocx = exportTableToDocx;
 
+export function exportTableToExcel(tableId, filename) {
+    const table = document.getElementById(tableId);
+    if (!table) return;
+    if (!window.XLSX) {
+        alert('Excel export is unavailable.');
+        return;
+    }
+    const wb = XLSX.utils.table_to_book(table, { sheet: 'Sheet1' });
+    const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+};
+window.exportTableToExcel = exportTableToExcel;
+
 export function printElement(elementId) {
     const el = document.getElementById(elementId);
     if (!el) return;

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -9,6 +9,13 @@ window.initSortable = (selector, dotnetHelper) => {
             group: 'rows',
             animation: 150,
             handle: '.drag-handle',
+            draggable: '[data-id]',
+            filter: '.no-drop, .no-drop *',
+            onMove: function (evt) {
+                if (evt.related && (evt.related.classList.contains('no-drop') || evt.related.closest('.no-drop'))) {
+                    return false;
+                }
+            },
             onEnd: function (evt) {
                 const fromRow = evt.from.getAttribute('data-row');
                 const toRow = evt.to.getAttribute('data-row');


### PR DESCRIPTION
## Summary
- allow form owners to disable or re-enable their forms
- expose new endpoint to set a form's active status
- list forms even when inactive and show switch in **My Forms** page
- generalize deleted-form alert message

## Testing
- `dotnet build DynamicFormsApp.sln --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6f66a8a083299c88e84f856b6e5b