### PR TITLE
Improve form availability toggling

### DIFF
--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -430,6 +430,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
+            IsEnabled = true,
             IsDraft = draft,
             Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
             {

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -16,7 +16,10 @@
 <h2 class="mb-2">Form Builder</h2>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -239,6 +239,7 @@
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
+            IsEnabled = true,
             Fields = fields.Select(f => new
             {
                 Label = f.Label,

--- a/Client/Pages/DynamicForms/FormHistory.razor
+++ b/Client/Pages/DynamicForms/FormHistory.razor
@@ -9,7 +9,10 @@
 <h3 class="mb-3">Form Versions</h3>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 
 @if (!isLoaded)

--- a/Client/Pages/DynamicForms/FormHistory.razor
+++ b/Client/Pages/DynamicForms/FormHistory.razor
@@ -12,9 +12,13 @@
     <div class="alert alert-warning">@deletedMessage</div>
 }
 
-@if (versions == null)
+@if (!isLoaded)
 {
     <p>Loading...</p>
+}
+else if (versions == null)
+{
+    <!-- nothing -->
 }
 else
 {
@@ -36,6 +40,7 @@ else
     [Parameter] public int FormId { get; set; }
     private List<Form>? versions;
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -61,11 +66,13 @@ else
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
 
             versions = await resp.Content.ReadFromJsonAsync<List<Form>>();
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -13,7 +13,10 @@
 <p class="text-muted">@form?.Description</p>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 
 @if (!isLoaded)

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -9,18 +9,18 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 
-<h3>@(form?.Name ?? "Loading…")</h3>
+<h3>@(form?.Name ?? (isLoaded ? string.Empty : "Loading…"))</h3>
 <p class="text-muted">@form?.Description</p>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
     <div class="alert alert-warning">@deletedMessage</div>
 }
 
-@if (form == null)
+@if (!isLoaded)
 {
     <p><em>Loading form…</em></p>
 }
-else
+else if (form != null)
 {
     <EditForm Model="@responseData">
         @{
@@ -175,6 +175,7 @@ else
     private Form form;
     private Dictionary<string, object> responseData = new();
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -192,6 +193,7 @@ else
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -220,6 +222,7 @@ else
                 };
             }
 
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -17,9 +17,13 @@
         <div class="alert alert-warning">@deletedMessage</div>
     }
 
-    @if (form == null || responses == null)
+    @if (!isLoaded)
     {
         <div class="alert alert-info">Loading responses...</div>
+    }
+    else if (form == null || responses == null)
+    {
+        <!-- nothing -->
     }
     else if (!responses.Any())
     {
@@ -97,6 +101,7 @@
     private string[] columns = Array.Empty<string>();
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -123,6 +128,7 @@
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -132,6 +138,7 @@
             if (!respData.IsSuccessStatusCode)
             {
                 deletedMessage = "Unable to load responses.";
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -149,6 +156,7 @@
             }
 
             exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -14,7 +14,10 @@
     <p class="text-muted">@form?.Description</p>
     @if (!string.IsNullOrEmpty(deletedMessage))
     {
-        <div class="alert alert-warning">@deletedMessage</div>
+        var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+            ? "alert alert-danger"
+            : "alert alert-warning";
+        <div class="@cls">@deletedMessage</div>
     }
 
     @if (!isLoaded)

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -11,7 +11,10 @@
 <p class="text-muted">@form?.Description</p>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 
 @if (!isLoaded)

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -14,9 +14,13 @@
     <div class="alert alert-warning">@deletedMessage</div>
 }
 
-@if (form == null || responses == null)
+@if (!isLoaded)
 {
     <p>Loading summary...</p>
+}
+else if (form == null || responses == null)
+{
+    <!-- nothing -->
 }
 else if (!responses.Any())
 {
@@ -76,6 +80,7 @@ else
     private Form form;
     private List<Dictionary<string, object>> responses;
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -101,6 +106,7 @@ else
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -110,11 +116,13 @@ else
             if (!resp.IsSuccessStatusCode)
             {
                 deletedMessage = "Unable to load responses.";
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
             responses = await resp.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
 
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -336,6 +336,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
+            IsEnabled = true,
             Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
             {
                 f.Label,

--- a/Client/Pages/DynamicForms/MyForms.razor
+++ b/Client/Pages/DynamicForms/MyForms.razor
@@ -25,6 +25,7 @@ else
                 <tr>
                     <th>Name</th>
                     <th>Description</th>
+                    <th>Active</th>
                     <th></th>
                 </tr>
             </thead>
@@ -34,6 +35,7 @@ else
                     <tr>
                         <td>@f.Name</td>
                         <td>@f.Description</td>
+                        <td><input type="checkbox" checked="@f.IsActive" @onchange="e => ToggleActive(f, e)" /></td>
                         <td>
                             <a class="btn btn-sm btn-primary me-2" href="@($"/forms/{f.Id}")">Open</a>
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/edit")">Edit</a>
@@ -100,6 +102,14 @@ else
                 Summary = "Form Deleted",
                 Detail = item.Name
             });
+        StateHasChanged();
+    }
+
+    private async Task ToggleActive(Form form, ChangeEventArgs e)
+    {
+        bool newValue = e?.Value is bool b && b;
+        await Http.PutAsJsonAsync($"api/forms/{form.Id}/active", newValue);
+        form.IsActive = newValue;
         StateHasChanged();
     }
 

--- a/Client/Pages/DynamicForms/MyForms.razor
+++ b/Client/Pages/DynamicForms/MyForms.razor
@@ -35,7 +35,7 @@ else
                     <tr>
                         <td>@f.Name</td>
                         <td>@f.Description</td>
-                        <td><input type="checkbox" checked="@f.IsActive" @onchange="e => ToggleActive(f, e)" /></td>
+                        <td><input type="checkbox" checked="@f.IsEnabled" @onchange="e => ToggleActive(f, e)" /></td>
                         <td>
                             <a class="btn btn-sm btn-primary me-2" href="@($"/forms/{f.Id}")">Open</a>
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/edit")">Edit</a>
@@ -108,8 +108,8 @@ else
     private async Task ToggleActive(Form form, ChangeEventArgs e)
     {
         bool newValue = e?.Value is bool b && b;
-        await Http.PutAsJsonAsync($"api/forms/{form.Id}/active", newValue);
-        form.IsActive = newValue;
+        await Http.PutAsJsonAsync($"api/forms/{form.Id}/enabled", newValue);
+        form.IsEnabled = newValue;
         StateHasChanged();
     }
 

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -21,7 +21,10 @@
 </div>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 <p class="text-muted">@form?.Description</p>
 <div class="mb-3" role="group">

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -31,9 +31,13 @@
     <button class="btn btn-outline-info" @onclick="DownloadExcel">Download Excel</button>
 </div>
 
-@if (form == null || response == null)
+@if (!isLoaded)
 {
     <p>Loading...</p>
+}
+else if (form == null || response == null)
+{
+    <!-- nothing -->
 }
 else
 {
@@ -80,6 +84,7 @@ else
     private string? responderName;
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -106,6 +111,7 @@ else
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -116,6 +122,7 @@ else
             if (!resp.IsSuccessStatusCode)
             {
                 deletedMessage = "Response not found.";
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -125,6 +132,7 @@ else
                 responderName = respName?.ToString();
             }
             exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/NdaProcesses.Shared/Models/CreateFormDto.cs
+++ b/NdaProcesses.Shared/Models/CreateFormDto.cs
@@ -11,6 +11,7 @@ namespace DynamicFormsApp.Shared.Models
         public bool NotifyOnResponse { get; set; } = false;
         public string? NotificationEmail { get; set; }
         public bool IsActive { get; set; } = true;
+        public bool IsEnabled { get; set; } = true;
         public bool IsDraft { get; set; } = false;
     }
 }

--- a/NdaProcesses.Shared/Models/Form.cs
+++ b/NdaProcesses.Shared/Models/Form.cs
@@ -18,6 +18,7 @@ namespace DynamicFormsApp.Shared.Models
         public bool NotifyOnResponse { get; set; } = false;
         public string? NotificationEmail { get; set; }
         public bool IsActive { get; set; } = true;
+        public bool IsEnabled { get; set; } = true;
         public bool IsDraft { get; set; } = false;
         public int Version { get; set; } = 1;
         public int? PreviousVersionId { get; set; }

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -31,7 +31,7 @@ namespace DynamicFormsApp.Server.Controllers
                 return Unauthorized();
             }
 
-            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Description, dto.Fields, user, dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive, dto.IsDraft);
+            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Description, dto.Fields, user, dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive, dto.IsEnabled, dto.IsDraft);
             return Ok(new { FormId = newFormId });
         }
 
@@ -63,6 +63,16 @@ namespace DynamicFormsApp.Server.Controllers
                 var owner = await _userSvc.GetUserData(form.CreatedBy);
                 return StatusCode(410, new
                 {
+                    Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
+            if (!form.IsEnabled)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
                     Message = "This form is no longer available. Please contact the owner.",
                     Owner = owner?.DisplayName ?? form.CreatedBy,
                     Email = owner?.Email
@@ -83,6 +93,16 @@ namespace DynamicFormsApp.Server.Controllers
 
             var form = await _svc.GetFormAsync(id);
             if (!form.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
+            if (!form.IsEnabled)
             {
                 var owner = await _userSvc.GetUserData(form.CreatedBy);
                 return StatusCode(410, new
@@ -108,6 +128,16 @@ namespace DynamicFormsApp.Server.Controllers
                 var owner = await _userSvc.GetUserData(form.CreatedBy);
                 return StatusCode(410, new
                 {
+                    Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
+            if (!form.IsEnabled)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
                     Message = "This form is no longer available. Please contact the owner.",
                     Owner = owner?.DisplayName ?? form.CreatedBy,
                     Email = owner?.Email
@@ -121,6 +151,16 @@ namespace DynamicFormsApp.Server.Controllers
         {
             var current = await _svc.GetFormAsync(id);
             if (!current.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(current.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? current.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
+            if (!current.IsEnabled)
             {
                 var owner = await _userSvc.GetUserData(current.CreatedBy);
                 return StatusCode(410, new
@@ -205,15 +245,15 @@ namespace DynamicFormsApp.Server.Controllers
             return NoContent();
         }
 
-        [HttpPut("{id}/active")]
-        public async Task<IActionResult> SetActive(int id, [FromBody] bool active)
+        [HttpPut("{id}/enabled")]
+        public async Task<IActionResult> SetEnabled(int id, [FromBody] bool enabled)
         {
             if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
             {
                 return Unauthorized();
             }
 
-            await _svc.SetActiveStateAsync(id, user, active);
+            await _svc.SetEnabledStateAsync(id, user, enabled);
             return NoContent();
         }
 
@@ -263,6 +303,16 @@ namespace DynamicFormsApp.Server.Controllers
                 string? responder = null;
                 var form = await _svc.GetFormAsync(id);
                 if (!form.IsActive)
+                {
+                    var owner = await _userSvc.GetUserData(form.CreatedBy);
+                    return StatusCode(410, new
+                    {
+                        Message = "This form has been deleted. Please contact the owner.",
+                        Owner = owner?.DisplayName ?? form.CreatedBy,
+                        Email = owner?.Email
+                    });
+                }
+                if (!form.IsEnabled)
                 {
                     var owner = await _userSvc.GetUserData(form.CreatedBy);
                     return StatusCode(410, new

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -63,7 +63,7 @@ namespace DynamicFormsApp.Server.Controllers
                 var owner = await _userSvc.GetUserData(form.CreatedBy);
                 return StatusCode(410, new
                 {
-                    Message = "This form has been deleted. Please contact the owner.",
+                    Message = "This form is no longer available. Please contact the owner.",
                     Owner = owner?.DisplayName ?? form.CreatedBy,
                     Email = owner?.Email
                 });
@@ -87,7 +87,7 @@ namespace DynamicFormsApp.Server.Controllers
                 var owner = await _userSvc.GetUserData(form.CreatedBy);
                 return StatusCode(410, new
                 {
-                    Message = "This form has been deleted. Please contact the owner.",
+                    Message = "This form is no longer available. Please contact the owner.",
                     Owner = owner?.DisplayName ?? form.CreatedBy,
                     Email = owner?.Email
                 });
@@ -108,7 +108,7 @@ namespace DynamicFormsApp.Server.Controllers
                 var owner = await _userSvc.GetUserData(form.CreatedBy);
                 return StatusCode(410, new
                 {
-                    Message = "This form has been deleted. Please contact the owner.",
+                    Message = "This form is no longer available. Please contact the owner.",
                     Owner = owner?.DisplayName ?? form.CreatedBy,
                     Email = owner?.Email
                 });
@@ -125,7 +125,7 @@ namespace DynamicFormsApp.Server.Controllers
                 var owner = await _userSvc.GetUserData(current.CreatedBy);
                 return StatusCode(410, new
                 {
-                    Message = "This form has been deleted. Please contact the owner.",
+                    Message = "This form is no longer available. Please contact the owner.",
                     Owner = owner?.DisplayName ?? current.CreatedBy,
                     Email = owner?.Email
                 });
@@ -205,6 +205,18 @@ namespace DynamicFormsApp.Server.Controllers
             return NoContent();
         }
 
+        [HttpPut("{id}/active")]
+        public async Task<IActionResult> SetActive(int id, [FromBody] bool active)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            await _svc.SetActiveStateAsync(id, user, active);
+            return NoContent();
+        }
+
         [HttpPost("{id}/share")]
         public async Task<IActionResult> Share(int id, [FromBody] ShareFormDto dto)
         {
@@ -255,7 +267,7 @@ namespace DynamicFormsApp.Server.Controllers
                     var owner = await _userSvc.GetUserData(form.CreatedBy);
                     return StatusCode(410, new
                     {
-                        Message = "This form has been deleted. Please contact the owner.",
+                        Message = "This form is no longer available. Please contact the owner.",
                         Owner = owner?.DisplayName ?? form.CreatedBy,
                         Email = owner?.Email
                     });

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -318,7 +318,7 @@ namespace DynamicFormsApp.Server.Services
         {
             var query = _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.CreatedBy == user && f.IsActive);
+                .Where(f => f.CreatedBy == user);
 
             if (!includeDrafts)
             {
@@ -332,7 +332,7 @@ namespace DynamicFormsApp.Server.Services
         {
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.CreatedBy == user && f.IsDraft && f.IsActive)
+                .Where(f => f.CreatedBy == user && f.IsDraft)
                 .ToListAsync();
         }
 

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -65,7 +65,7 @@ namespace DynamicFormsApp.Server.Services
 
                     var newId = await CreateFormAsync(dto.Name, dto.Description, dto.Fields, user,
                         dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive,
-                        dto.IsDraft, existing.Version + 1, existing.Id);
+                        dto.IsEnabled, dto.IsDraft, existing.Version + 1, existing.Id);
 
                     return newId;
                 }
@@ -89,6 +89,7 @@ namespace DynamicFormsApp.Server.Services
             existing.NotifyOnResponse = dto.NotifyOnResponse;
             existing.NotificationEmail = dto.NotificationEmail;
             existing.IsActive = dto.IsActive;
+            existing.IsEnabled = dto.IsEnabled;
             existing.IsDraft = dto.IsDraft;
 
             var keySet = new HashSet<string>(existing.Fields.Select(f => f.Key), StringComparer.OrdinalIgnoreCase);
@@ -136,7 +137,7 @@ namespace DynamicFormsApp.Server.Services
         }
 
 
-        public async Task<int> CreateFormAsync(string formName, string? description, List<CreateFieldDto> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive, bool isDraft = false, int version = 1, int? previousVersionId = null)
+        public async Task<int> CreateFormAsync(string formName, string? description, List<CreateFieldDto> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive, bool isEnabled, bool isDraft = false, int version = 1, int? previousVersionId = null)
         {
             var form = new Form
             {
@@ -147,6 +148,7 @@ namespace DynamicFormsApp.Server.Services
                 NotifyOnResponse = notifyOnResponse,
                 NotificationEmail = notificationEmail,
                 IsActive = isActive,
+                IsEnabled = isEnabled,
                 IsDraft = isDraft,
                 Version = version,
                 PreviousVersionId = previousVersionId,
@@ -204,7 +206,7 @@ namespace DynamicFormsApp.Server.Services
         {
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
-            if (!form.IsActive)
+            if (!form.IsActive || !form.IsEnabled)
             {
                 throw new InvalidOperationException("Form inactive");
             }
@@ -275,7 +277,7 @@ namespace DynamicFormsApp.Server.Services
             await _db.SaveChangesAsync();
         }
 
-        public async Task SetActiveStateAsync(int formId, string user, bool isActive)
+        public async Task SetEnabledStateAsync(int formId, string user, bool isEnabled)
         {
             var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.CreatedBy == user);
             if (form == null)
@@ -283,7 +285,7 @@ namespace DynamicFormsApp.Server.Services
                 throw new InvalidOperationException("Form not found");
             }
 
-            form.IsActive = isActive;
+            form.IsEnabled = isEnabled;
             await _db.SaveChangesAsync();
         }
 
@@ -291,20 +293,20 @@ namespace DynamicFormsApp.Server.Services
         {
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.IsActive && !f.IsDraft)
+                .Where(f => f.IsActive && f.IsEnabled && !f.IsDraft)
                 .ToListAsync();
         }
 
         public async Task<int> GetFormCountAsync()
         {
-            return await _db.Forms.CountAsync(f => f.IsActive && !f.IsDraft);
+            return await _db.Forms.CountAsync(f => f.IsActive && f.IsEnabled && !f.IsDraft);
         }
 
         public async Task<List<Form>> SearchFormsAsync(bool includePrivate)
         {
             var query = _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.IsActive && !f.IsDraft);
+                .Where(f => f.IsActive && f.IsEnabled && !f.IsDraft);
 
             if (!includePrivate)
             {
@@ -391,7 +393,7 @@ namespace DynamicFormsApp.Server.Services
             var formIds = await _db.FormShares.Where(s => s.UserName == user).Select(s => s.FormId).ToListAsync();
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => formIds.Contains(f.Id) && f.IsActive)
+                .Where(f => formIds.Contains(f.Id) && f.IsActive && f.IsEnabled)
                 .ToListAsync();
         }
 
@@ -439,7 +441,7 @@ namespace DynamicFormsApp.Server.Services
 
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
-            if (!form.IsActive)
+            if (!form.IsActive || !form.IsEnabled)
             {
                 throw new InvalidOperationException("Form inactive");
             }
@@ -480,7 +482,7 @@ namespace DynamicFormsApp.Server.Services
 
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
-            if (!form.IsActive)
+            if (!form.IsActive || !form.IsEnabled)
             {
                 throw new InvalidOperationException("Form inactive");
             }

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -275,6 +275,18 @@ namespace DynamicFormsApp.Server.Services
             await _db.SaveChangesAsync();
         }
 
+        public async Task SetActiveStateAsync(int formId, string user, bool isActive)
+        {
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.CreatedBy == user);
+            if (form == null)
+            {
+                throw new InvalidOperationException("Form not found");
+            }
+
+            form.IsActive = isActive;
+            await _db.SaveChangesAsync();
+        }
+
         public async Task<List<Form>> GetAllFormsAsync()
         {
             return await _db.Forms


### PR DESCRIPTION
## Summary
- allow toggling form availability from My Forms
- handle forms that are disabled with clearer messaging
- fix pages that kept showing loading text after a disabled form was loaded

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9e1d9d808329814700d0fc5f437a