### PR TITLE
Improve form availability handling

### DIFF
--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -16,7 +16,10 @@
 <h2 class="mb-2">Form Builder</h2>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 
@@ -427,6 +430,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
+            IsAvailable = true,
             IsDraft = draft,
             Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
             {

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -239,6 +239,7 @@
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
+            IsAvailable = true,
             Fields = fields.Select(f => new
             {
                 Label = f.Label,

--- a/Client/Pages/DynamicForms/FormHistory.razor
+++ b/Client/Pages/DynamicForms/FormHistory.razor
@@ -9,12 +9,19 @@
 <h3 class="mb-3">Form Versions</h3>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 
-@if (versions == null)
+@if (!isLoaded)
 {
     <p>Loading...</p>
+}
+else if (versions == null)
+{
+    <!-- nothing -->
 }
 else
 {
@@ -36,6 +43,7 @@ else
     [Parameter] public int FormId { get; set; }
     private List<Form>? versions;
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -61,11 +69,13 @@ else
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
 
             versions = await resp.Content.ReadFromJsonAsync<List<Form>>();
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -9,18 +9,21 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 
-<h3>@(form?.Name ?? "Loading…")</h3>
+<h3>@(form?.Name ?? (isLoaded ? string.Empty : "Loading…"))</h3>
 <p class="text-muted">@form?.Description</p>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 
-@if (form == null)
+@if (!isLoaded)
 {
     <p><em>Loading form…</em></p>
 }
-else
+else if (form != null)
 {
     <EditForm Model="@responseData">
         @{
@@ -175,6 +178,7 @@ else
     private Form form;
     private Dictionary<string, object> responseData = new();
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -192,6 +196,7 @@ else
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -220,6 +225,7 @@ else
                 };
             }
 
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -14,12 +14,19 @@
     <p class="text-muted">@form?.Description</p>
     @if (!string.IsNullOrEmpty(deletedMessage))
     {
-        <div class="alert alert-warning">@deletedMessage</div>
+        var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+            ? "alert alert-danger"
+            : "alert alert-warning";
+        <div class="@cls">@deletedMessage</div>
     }
 
-    @if (form == null || responses == null)
+    @if (!isLoaded)
     {
         <div class="alert alert-info">Loading responses...</div>
+    }
+    else if (form == null || responses == null)
+    {
+        <!-- nothing -->
     }
     else if (!responses.Any())
     {
@@ -97,6 +104,7 @@
     private string[] columns = Array.Empty<string>();
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -123,6 +131,7 @@
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -132,6 +141,7 @@
             if (!respData.IsSuccessStatusCode)
             {
                 deletedMessage = "Unable to load responses.";
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -149,6 +159,7 @@
             }
 
             exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -11,12 +11,19 @@
 <p class="text-muted">@form?.Description</p>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 
-@if (form == null || responses == null)
+@if (!isLoaded)
 {
     <p>Loading summary...</p>
+}
+else if (form == null || responses == null)
+{
+    <!-- nothing -->
 }
 else if (!responses.Any())
 {
@@ -76,6 +83,7 @@ else
     private Form form;
     private List<Dictionary<string, object>> responses;
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -101,6 +109,7 @@ else
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -110,11 +119,13 @@ else
             if (!resp.IsSuccessStatusCode)
             {
                 deletedMessage = "Unable to load responses.";
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
             responses = await resp.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
 
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -336,6 +336,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
+            IsAvailable = true,
             Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
             {
                 f.Label,

--- a/Client/Pages/DynamicForms/MyForms.razor
+++ b/Client/Pages/DynamicForms/MyForms.razor
@@ -25,6 +25,7 @@ else
                 <tr>
                     <th>Name</th>
                     <th>Description</th>
+                    <th>Available</th>
                     <th></th>
                 </tr>
             </thead>
@@ -34,6 +35,7 @@ else
                     <tr>
                         <td>@f.Name</td>
                         <td>@f.Description</td>
+                        <td><input type="checkbox" checked="@f.IsAvailable" @onchange="e => ToggleAvailable(f, e)" /></td>
                         <td>
                             <a class="btn btn-sm btn-primary me-2" href="@($"/forms/{f.Id}")">Open</a>
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/edit")">Edit</a>
@@ -100,6 +102,14 @@ else
                 Summary = "Form Deleted",
                 Detail = item.Name
             });
+        StateHasChanged();
+    }
+
+    private async Task ToggleAvailable(Form form, ChangeEventArgs e)
+    {
+        bool newValue = e?.Value is bool b && b;
+        await Http.PutAsJsonAsync($"api/forms/{form.Id}/available", newValue);
+        form.IsAvailable = newValue;
         StateHasChanged();
     }
 

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -21,7 +21,10 @@
 </div>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
-    <div class="alert alert-warning">@deletedMessage</div>
+    var cls = deletedMessage.Contains("deleted", StringComparison.OrdinalIgnoreCase)
+        ? "alert alert-danger"
+        : "alert alert-warning";
+    <div class="@cls">@deletedMessage</div>
 }
 <p class="text-muted">@form?.Description</p>
 <div class="mb-3" role="group">
@@ -31,9 +34,13 @@
     <button class="btn btn-outline-info" @onclick="DownloadExcel">Download Excel</button>
 </div>
 
-@if (form == null || response == null)
+@if (!isLoaded)
 {
     <p>Loading...</p>
+}
+else if (form == null || response == null)
+{
+    <!-- nothing -->
 }
 else
 {
@@ -80,6 +87,7 @@ else
     private string? responderName;
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
+    private bool isLoaded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -106,6 +114,7 @@ else
                 {
                     deletedMessage = "Form not found.";
                 }
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -116,6 +125,7 @@ else
             if (!resp.IsSuccessStatusCode)
             {
                 deletedMessage = "Response not found.";
+                isLoaded = true;
                 StateHasChanged();
                 return;
             }
@@ -125,6 +135,7 @@ else
                 responderName = respName?.ToString();
             }
             exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
+            isLoaded = true;
             StateHasChanged();
         }
     }

--- a/NdaProcesses.Shared/Models/CreateFormDto.cs
+++ b/NdaProcesses.Shared/Models/CreateFormDto.cs
@@ -11,6 +11,7 @@ namespace DynamicFormsApp.Shared.Models
         public bool NotifyOnResponse { get; set; } = false;
         public string? NotificationEmail { get; set; }
         public bool IsActive { get; set; } = true;
+        public bool IsAvailable { get; set; } = true;
         public bool IsDraft { get; set; } = false;
     }
 }

--- a/NdaProcesses.Shared/Models/Form.cs
+++ b/NdaProcesses.Shared/Models/Form.cs
@@ -18,6 +18,7 @@ namespace DynamicFormsApp.Shared.Models
         public bool NotifyOnResponse { get; set; } = false;
         public string? NotificationEmail { get; set; }
         public bool IsActive { get; set; } = true;
+        public bool IsAvailable { get; set; } = true;
         public bool IsDraft { get; set; } = false;
         public int Version { get; set; } = 1;
         public int? PreviousVersionId { get; set; }

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -31,7 +31,7 @@ namespace DynamicFormsApp.Server.Controllers
                 return Unauthorized();
             }
 
-            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Description, dto.Fields, user, dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive, dto.IsDraft);
+            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Description, dto.Fields, user, dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive, dto.IsAvailable, dto.IsDraft);
             return Ok(new { FormId = newFormId });
         }
 
@@ -68,6 +68,16 @@ namespace DynamicFormsApp.Server.Controllers
                     Email = owner?.Email
                 });
             }
+            if (!form.IsAvailable)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form is no longer available. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
 
             var rows = await _svc.GetResponsesAsync(id, user);
             return Ok(rows);
@@ -92,6 +102,16 @@ namespace DynamicFormsApp.Server.Controllers
                     Email = owner?.Email
                 });
             }
+            if (!form.IsAvailable)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form is no longer available. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
 
             var row = await _svc.GetResponseAsync(id, responseId, user);
             return Ok(row);
@@ -103,12 +123,24 @@ namespace DynamicFormsApp.Server.Controllers
         public async Task<ActionResult<Form>> Get(int id)
         {
             var form = await _svc.GetFormAsync(id);
-            if (!form.IsActive)
+            var requesterIsOwner = Request.Cookies.TryGetValue("userName", out var user) && user == form.CreatedBy;
+
+            if (!form.IsActive && !requesterIsOwner)
             {
                 var owner = await _userSvc.GetUserData(form.CreatedBy);
                 return StatusCode(410, new
                 {
                     Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
+            if (!form.IsAvailable && !requesterIsOwner)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form is no longer available. Please contact the owner.",
                     Owner = owner?.DisplayName ?? form.CreatedBy,
                     Email = owner?.Email
                 });
@@ -126,6 +158,16 @@ namespace DynamicFormsApp.Server.Controllers
                 return StatusCode(410, new
                 {
                     Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? current.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
+            if (!current.IsAvailable)
+            {
+                var owner = await _userSvc.GetUserData(current.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form is no longer available. Please contact the owner.",
                     Owner = owner?.DisplayName ?? current.CreatedBy,
                     Email = owner?.Email
                 });
@@ -205,6 +247,30 @@ namespace DynamicFormsApp.Server.Controllers
             return NoContent();
         }
 
+        [HttpPut("{id}/active")]
+        public async Task<IActionResult> SetActive(int id, [FromBody] bool active)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            await _svc.SetActiveStateAsync(id, user, active);
+            return NoContent();
+        }
+
+        [HttpPut("{id}/available")]
+        public async Task<IActionResult> SetAvailable(int id, [FromBody] bool available)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            await _svc.SetAvailableStateAsync(id, user, available);
+            return NoContent();
+        }
+
         [HttpPost("{id}/share")]
         public async Task<IActionResult> Share(int id, [FromBody] ShareFormDto dto)
         {
@@ -256,6 +322,16 @@ namespace DynamicFormsApp.Server.Controllers
                     return StatusCode(410, new
                     {
                         Message = "This form has been deleted. Please contact the owner.",
+                        Owner = owner?.DisplayName ?? form.CreatedBy,
+                        Email = owner?.Email
+                    });
+                }
+                if (!form.IsAvailable)
+                {
+                    var owner = await _userSvc.GetUserData(form.CreatedBy);
+                    return StatusCode(410, new
+                    {
+                        Message = "This form is no longer available. Please contact the owner.",
                         Owner = owner?.DisplayName ?? form.CreatedBy,
                         Email = owner?.Email
                     });

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -65,7 +65,7 @@ namespace DynamicFormsApp.Server.Services
 
                     var newId = await CreateFormAsync(dto.Name, dto.Description, dto.Fields, user,
                         dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive,
-                        dto.IsDraft, existing.Version + 1, existing.Id);
+                        dto.IsAvailable, dto.IsDraft, existing.Version + 1, existing.Id);
 
                     return newId;
                 }
@@ -89,6 +89,7 @@ namespace DynamicFormsApp.Server.Services
             existing.NotifyOnResponse = dto.NotifyOnResponse;
             existing.NotificationEmail = dto.NotificationEmail;
             existing.IsActive = dto.IsActive;
+            existing.IsAvailable = dto.IsAvailable;
             existing.IsDraft = dto.IsDraft;
 
             var keySet = new HashSet<string>(existing.Fields.Select(f => f.Key), StringComparer.OrdinalIgnoreCase);
@@ -136,7 +137,7 @@ namespace DynamicFormsApp.Server.Services
         }
 
 
-        public async Task<int> CreateFormAsync(string formName, string? description, List<CreateFieldDto> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive, bool isDraft = false, int version = 1, int? previousVersionId = null)
+        public async Task<int> CreateFormAsync(string formName, string? description, List<CreateFieldDto> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive, bool isAvailable = true, bool isDraft = false, int version = 1, int? previousVersionId = null)
         {
             var form = new Form
             {
@@ -147,6 +148,7 @@ namespace DynamicFormsApp.Server.Services
                 NotifyOnResponse = notifyOnResponse,
                 NotificationEmail = notificationEmail,
                 IsActive = isActive,
+                IsAvailable = isAvailable,
                 IsDraft = isDraft,
                 Version = version,
                 PreviousVersionId = previousVersionId,
@@ -204,7 +206,7 @@ namespace DynamicFormsApp.Server.Services
         {
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
-            if (!form.IsActive)
+            if (!form.IsActive || !form.IsAvailable)
             {
                 throw new InvalidOperationException("Form inactive");
             }
@@ -272,6 +274,31 @@ namespace DynamicFormsApp.Server.Services
             }
 
             form.IsActive = false;
+            form.IsAvailable = false;
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task SetActiveStateAsync(int formId, string user, bool isActive)
+        {
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.CreatedBy == user);
+            if (form == null)
+            {
+                throw new InvalidOperationException("Form not found");
+            }
+
+            form.IsActive = isActive;
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task SetAvailableStateAsync(int formId, string user, bool isAvailable)
+        {
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.CreatedBy == user);
+            if (form == null)
+            {
+                throw new InvalidOperationException("Form not found");
+            }
+
+            form.IsAvailable = isAvailable;
             await _db.SaveChangesAsync();
         }
 
@@ -279,20 +306,20 @@ namespace DynamicFormsApp.Server.Services
         {
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.IsActive && !f.IsDraft)
+                .Where(f => f.IsActive && f.IsAvailable && !f.IsDraft)
                 .ToListAsync();
         }
 
         public async Task<int> GetFormCountAsync()
         {
-            return await _db.Forms.CountAsync(f => f.IsActive && !f.IsDraft);
+            return await _db.Forms.CountAsync(f => f.IsActive && f.IsAvailable && !f.IsDraft);
         }
 
         public async Task<List<Form>> SearchFormsAsync(bool includePrivate)
         {
             var query = _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.IsActive && !f.IsDraft);
+                .Where(f => f.IsActive && f.IsAvailable && !f.IsDraft);
 
             if (!includePrivate)
             {
@@ -379,7 +406,7 @@ namespace DynamicFormsApp.Server.Services
             var formIds = await _db.FormShares.Where(s => s.UserName == user).Select(s => s.FormId).ToListAsync();
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => formIds.Contains(f.Id) && f.IsActive)
+                .Where(f => formIds.Contains(f.Id) && f.IsActive && f.IsAvailable)
                 .ToListAsync();
         }
 
@@ -427,7 +454,7 @@ namespace DynamicFormsApp.Server.Services
 
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
-            if (!form.IsActive)
+            if (!form.IsActive || !form.IsAvailable)
             {
                 throw new InvalidOperationException("Form inactive");
             }
@@ -468,7 +495,7 @@ namespace DynamicFormsApp.Server.Services
 
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
-            if (!form.IsActive)
+            if (!form.IsActive || !form.IsAvailable)
             {
                 throw new InvalidOperationException("Form inactive");
             }


### PR DESCRIPTION
## Summary
- introduce separate `IsAvailable` flag
- allow owners to toggle availability from **My Forms**
- distinguish between deleted and disabled forms on the backend
- add ability to toggle a form's active state and restore deleted forms
- fix indefinite loading messages on disabled/deleted forms
- remove the `Active` toggle from **My Forms** and exclude deleted forms from the list

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9e1d9d808329814700d0fc5f437a